### PR TITLE
Corrected link with new page name for using a private registry

### DIFF
--- a/02 System Requirements.md
+++ b/02 System Requirements.md
@@ -14,7 +14,7 @@ HTTPS access is required for all Cloud Proxies that runs VCF Operations vCommuni
 After installing the .PAK file for the first time Cloud Proxy will try to pull the related container image from the registry. However, Cloud Proxy will try to pull the new container image after .PAK file upgrade process too. Since VCF Operations vCommunity MP continuesly updated it is recommended to have container registry access. This way, administrators can always easily upgrade this package.
 
 If your Cloud Proxy does not have Internet access, follow this to work with public registry.
-[Using a Private Registry for VCF Operations vCommunity MP](https://github.com/vmbro/VCF-Operations-vCommunity/blob/main/Working-with-Private-Registry.md#using-a-private-registry-for-vcf-operations-vcommunity-mp)
+[Using a Private Registry for VCF Operations vCommunity MP](https://github.com/vmbro/VCF-Operations-vCommunity/blob/main/05%20Dark%20Site.md#using-a-private-registry-for-vcf-operations-vcommunity-mp)
 
 FYI, Internet proxy setting is available durng the OVF deployment.
 


### PR DESCRIPTION
Old link led to 404 error, as the page name was likely changed after original hyperlinking.